### PR TITLE
[2.x] Add support for multi refresh routes

### DIFF
--- a/config/sanctum-refresh-token.php
+++ b/config/sanctum-refresh-token.php
@@ -2,13 +2,15 @@
 return [
     /*
     |--------------------------------------------------------------------------
-    | Refresh Route Name
+    | Refresh Route Names
     |--------------------------------------------------------------------------
     |
-    | This value controls the used refresh route name
+    | This value controls the used refresh route names
     |
     */
-      'refresh_route_name'      => 'api.token.refresh',
+    'refresh_route_names' => [
+      'api.token.refresh'
+    ],
 
     /*
     |--------------------------------------------------------------------------
@@ -19,6 +21,6 @@ return [
     | considered expired.
     |
     */
-     'auth_token_expiration'    => 60,
-     'refresh_token_expiration' => 180,
+    'auth_token_expiration'    => 60,
+    'refresh_token_expiration' => 180,
 ];

--- a/config/sanctum-refresh-token.php
+++ b/config/sanctum-refresh-token.php
@@ -8,9 +8,7 @@ return [
     | This value controls the used refresh route names
     |
     */
-    'refresh_route_names' => [
-      'api.token.refresh'
-    ],
+    'refresh_route_names' => 'api.token.refresh',
 
     /*
     |--------------------------------------------------------------------------

--- a/src/SanctumRefreshTokenServiceProvider.php
+++ b/src/SanctumRefreshTokenServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace MohamedGaber\SanctumRefreshToken;
 
-use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
@@ -46,7 +45,12 @@ class SanctumRefreshTokenServiceProvider extends ServiceProvider
 
     private function isTokenAbilityValid($token)
     {
-        return Arr::has(config('sanctum-refresh-token.refresh_route_names'), Route::currentRouteName()) ?
+        $routeNames = config('sanctum-refresh-token.refresh_route_names');
+        if (is_string($routeNames)) {
+            $routeNames = [$routeNames];
+        }
+        
+        return collect($routeNames)->contains(Route::currentRouteName()) ?
             $this->isRefreshTokenValid($token) :
             $this->isAuthTokenValid($token);
     }

--- a/src/SanctumRefreshTokenServiceProvider.php
+++ b/src/SanctumRefreshTokenServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace MohamedGaber\SanctumRefreshToken;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
@@ -45,7 +46,7 @@ class SanctumRefreshTokenServiceProvider extends ServiceProvider
 
     private function isTokenAbilityValid($token)
     {
-        return Route::currentRouteName() == config('sanctum-refresh-token.refresh_route_name') ?
+        return Arr::has(config('sanctum-refresh-token.refresh_route_names'), Route::currentRouteName()) ?
             $this->isRefreshTokenValid($token) :
             $this->isAuthTokenValid($token);
     }


### PR DESCRIPTION
Hi 👋🏻,

As the title suggests, this PR now allows us to specify multiple refresh route name.

The use case is for example in a multi-tenant application.

We want a first refresh route for the central application and a refresh route for each tenant.